### PR TITLE
Set a locale for DTASN1Parser's date formatter

### DIFF
--- a/Core/Source/DTASN1/DTASN1Parser.m
+++ b/Core/Source/DTASN1/DTASN1Parser.m
@@ -59,6 +59,7 @@
 		_UTCFormatter = [[NSDateFormatter alloc] init];
 		_UTCFormatter.dateFormat = @"yyMMddHHmmss'Z'";
 		_UTCFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+		_UTCFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
 		
 		if (!_dataLength)
 		{


### PR DESCRIPTION
Previously, DTASN1Parser could fail to parse dates when the user's locale normally used a 24-hour clock, but the user had manually switched to 12-hour time. Under these circumstances, the "HH" pattern tries to match 12-hour time, which fails. Explicitly setting a locale on the formatter corrects this problem.